### PR TITLE
Fix signature comparing

### DIFF
--- a/Sources/Decoy/Helpers/JSONValue.swift
+++ b/Sources/Decoy/Helpers/JSONValue.swift
@@ -79,11 +79,7 @@ public enum JSONValue: Codable, Hashable, CustomStringConvertible {
     case .string(let value):
       return value
     case .number(let value):
-      if value.truncatingRemainder(dividingBy: 1) == 0 {
-        return value
-      } else {
-        return value
-      }
+      return value
     case .bool(let value):
       return value
     case .array(let array):

--- a/Sources/Decoy/Helpers/JSONValue.swift
+++ b/Sources/Decoy/Helpers/JSONValue.swift
@@ -74,6 +74,30 @@ public enum JSONValue: Codable, Hashable, CustomStringConvertible {
     }
   }
 
+    public var jsonSerializationSafe: Any {
+      switch self {
+      case .string(let value):
+        return value
+      case .number(let value):
+        if value.truncatingRemainder(dividingBy: 1) == 0 {
+          return value
+        } else {
+          return value
+        }
+      case .bool(let value):
+        return value
+      case .array(let array):
+          return array.map { $0.jsonSerializationSafe }
+      case .object(let dict):
+        let items = dict
+          .sorted(by: { $0.key < $1.key })
+          .map { "\($0.key): \($0.value)" }
+        return "{" + items.joined(separator: ", ") + "}"
+      case .null:
+        return "null"
+      }
+    }
+
   /// Encodes this value into the given encoder.
   ///
   /// The encoding matches the JSON type represented by this value.

--- a/Sources/Decoy/Helpers/JSONValue.swift
+++ b/Sources/Decoy/Helpers/JSONValue.swift
@@ -74,29 +74,30 @@ public enum JSONValue: Codable, Hashable, CustomStringConvertible {
     }
   }
 
-    public var jsonSerializationSafe: Any {
-      switch self {
-      case .string(let value):
+  public var jsonSerializationSafe: Any {
+    switch self {
+    case .string(let value):
+      return value
+    case .number(let value):
+      if value.truncatingRemainder(dividingBy: 1) == 0 {
         return value
-      case .number(let value):
-        if value.truncatingRemainder(dividingBy: 1) == 0 {
-          return value
-        } else {
-          return value
-        }
-      case .bool(let value):
+      } else {
         return value
-      case .array(let array):
-          return array.map { $0.jsonSerializationSafe }
-      case .object(let dict):
-        let items = dict
-          .sorted(by: { $0.key < $1.key })
-          .map { "\($0.key): \($0.value)" }
-        return "{" + items.joined(separator: ", ") + "}"
-      case .null:
-        return "null"
       }
-    }
+    case .bool(let value):
+      return value
+    case .array(let array):
+      return array.map { $0.jsonSerializationSafe }
+    case .object(let dict):
+      var safeDict: [String: Any] = [:]
+      for (key, value) in dict {
+        safeDict[key] = value.jsonSerializationSafe
+      }
+      return safeDict
+    case .null:
+      return "null"
+  }
+ }
 
   /// Encodes this value into the given encoder.
   ///

--- a/Sources/Decoy/Helpers/JSONValue.swift
+++ b/Sources/Decoy/Helpers/JSONValue.swift
@@ -96,8 +96,8 @@ public enum JSONValue: Codable, Hashable, CustomStringConvertible {
       return safeDict
     case .null:
       return "null"
+    }
   }
- }
 
   /// Encodes this value into the given encoder.
   ///

--- a/Sources/Decoy/Helpers/JSONValue.swift
+++ b/Sources/Decoy/Helpers/JSONValue.swift
@@ -91,7 +91,7 @@ public enum JSONValue: Codable, Hashable, CustomStringConvertible {
       }
       return safeDict
     case .null:
-      return "null"
+      return NSNull()
     }
   }
 

--- a/Sources/Decoy/Stub.swift
+++ b/Sources/Decoy/Stub.swift
@@ -93,7 +93,7 @@ public struct Stub {
         "operationName": signature.operationName,
         "query": signature.query,
         "endpoint": signature.endpoint.absoluteString,
-        "variables": signature.variables.mapValues { $0.description }
+        "variables": signature.variables.mapValues { $0.jsonSerializationSafe }
       ]
     } else {
       fatalError("Attempted to record a stub with an invalid identifier.")


### PR DESCRIPTION
When writing to file from graphql queries, all types were being stored as strings in the variables fields
When we intercepted the request in .liveIfUnmocked mode they would be compared with their true types and fail

I opted to save to the file the true types rather than changing on interceptor side.

There are tests failing but they seem to be failing in main as well

