### PR TITLE
Add logStream tear down

### DIFF
--- a/Sources/DecoyXCUI/DecoyTestCase.swift
+++ b/Sources/DecoyXCUI/DecoyTestCase.swift
@@ -61,6 +61,12 @@ open class DecoyTestCase: XCTestCase {
     )
   }
 
+    override open func tearDown() {
+        logStream.tearDown()
+
+        super.tearDown()
+    }
+
   /// Builds the directory path for storing mock data.
   ///
   /// - Parameters:


### PR DESCRIPTION
Logs were being maintained between tests

Tested by pointing to this PR and seems to be ok now, but did not test extensively.